### PR TITLE
Separate base trait into separate file

### DIFF
--- a/contracts/rust/src/nep4/mod.rs
+++ b/contracts/rust/src/nep4/mod.rs
@@ -1,0 +1,33 @@
+use near_sdk::{AccountId};
+/// The token ID type is also defined in the NEP
+pub type TokenId = u64;
+
+/// This trait provides the baseline of functions as described at:
+/// https://github.com/nearprotocol/NEPs/blob/nep-4/specs/Standards/Tokens/NonFungibleToken.md
+pub trait NEP4 {
+    // Grant the access to the given `accountId` for the given `tokenId`.
+    // Requirements:
+    // * The caller of the function (`predecessor_id`) should have access to the token.
+    fn grant_access(&mut self, escrow_account_id: AccountId);
+
+    // Revoke the access to the given `accountId` for the given `tokenId`.
+    // Requirements:
+    // * The caller of the function (`predecessor_id`) should have access to the token.
+    fn revoke_access(&mut self, escrow_account_id: AccountId);
+
+    // Transfer the given `tokenId` from the given `accountId`.  Account `newAccountId` becomes the new owner.
+    // Requirements:
+    // * The caller of the function (`predecessor_id`) should have access to the token.
+    fn transfer_from(&mut self, owner_id: AccountId, new_owner_id: AccountId, token_id: TokenId);
+
+    // Transfer the given `tokenId` to the given `accountId`.  Account `accountId` becomes the new owner.
+    // Requirements:
+    // * The caller of the function (`predecessor_id`) should have access to the token.
+    fn transfer(&mut self, new_owner_id: AccountId, token_id: TokenId);
+
+    // Returns `true` or `false` based on caller of the function (`predecessor_id) having access to the token
+    fn check_access(&self, account_id: AccountId) -> bool;
+
+    // Get an individual owner by given `tokenId`.
+    fn get_token_owner(&self, token_id: TokenId) -> String;
+}


### PR DESCRIPTION
Using this as a guide:
https://doc.rust-lang.org/stable/rust-by-example/mod/split.html
separate the base trait for the NEP into its own file. Then the `lib.rs` file is implementing it.
In the future we could even have more implementations that simply use this as a `mod`.
Feels much better than cramming all the logic into one file.
Goal is for end-users to be able to make their own version of the NFT, which will very likely be different than our own, and this assists in the separation of base functions and actual implementation.