### PR TITLE
Update check_access to return true if signer is the same as account id

### DIFF
--- a/contracts/rust/src/lib.rs
+++ b/contracts/rust/src/lib.rs
@@ -112,7 +112,6 @@ impl NEP4 for NonFungibleTokenBasic {
     }
 
     fn check_access(&self, account_id: AccountId) -> bool {
-        // TODO: check access needs to allow transfer if signer account is the same as account_id
         let account_hash = env::sha256(account_id.as_bytes());
         let signer = env::signer_account_id();
         if signer == account_id {
@@ -311,9 +310,6 @@ mod tests {
         let mut contract = NonFungibleTokenBasic::new("robert.testnet".to_string());
         let token_id = 19u64;
         contract.mint_token("robert.testnet".to_string(), token_id);
-        // workaround until we can add self-check in check-access
-        // TODO: remove this line
-        contract.grant_access("robert.testnet".to_string());
 
         // Robert transfers the token to Joe
         contract.transfer("joe.testnet".to_string(), token_id);

--- a/contracts/rust/src/lib.rs
+++ b/contracts/rust/src/lib.rs
@@ -116,6 +116,10 @@ impl NEP4 for NonFungibleTokenBasic {
 
     fn check_access(&self, account_id: AccountId) -> bool {
         let account_hash = env::sha256(account_id.as_bytes());
+        let signer = env::signer_account_id();
+        if signer == account_id {
+            return true;
+        }
         match self.account_gives_access.get(&account_hash) {
             Some(access) => {
                 let signer = env::signer_account_id();


### PR DESCRIPTION
This currently fails the existing test