### PR TITLE
[Do not merge] Illustrate workaround for Set and Map in mocked_blockchain tests

### DIFF
--- a/contracts/rust/src/lib.rs
+++ b/contracts/rust/src/lib.rs
@@ -206,7 +206,7 @@ mod tests {
             block_timestamp: 0,
             account_balance: 0,
             account_locked_balance: 0,
-            storage_usage: 0,
+            storage_usage: 100,
             attached_deposit: 0,
             prepaid_gas: 10u64.pow(18),
             random_seed: vec![0, 1, 2],


### PR DESCRIPTION
The purpose of this PR is to share with the NEAR Collective in illustrating an issue that seems to be occurring with the collections [Set](https://github.com/near/near-sdk-rs/blob/master/near-sdk/src/collections/set.rs) and [Map](https://github.com/near/near-sdk-rs/blob/master/near-sdk/src/collections/map.rs) when applied to testing in the mocked blockchain context.

[Note line 107](https://github.com/near-examples/nfts/pull/14/files#diff-3c4c6049ddabf4205eeef1ccd59ff6c5R107) of `contracts/rust/src/lib.rs` calling a function `workaround()`. This workaround essentially inserts useless values into a Map and Set. After doing this, the tests work as expected. If the call to `workaround()` is commented out, we receive:

>thread 'tests::add_revoke_access_and_check' panicked at 'called `Result::unwrap()` on an `Err` value: InconsistentStateError(IntegerOverflow)', /Users/mike/.cargo/registry/src/github.com-1ecc6299db9ec823/near-sdk-0.9.2/src/environment/mocked_blockchain.rs:397:9

You'll note that there are two mocked context happening here. This is modeled after the tests found here:
https://github.com/near/near-sdk-rs/blob/master/examples/fungible-token/src/lib.rs#L295-L311

This seems of high importance for folks building Rust contracts and trying to write tests for the two data structures mentioned. For what it's worth, I believe this was specifically happening on the Set's `.remove` and I also saw this behavior on `.clear`.