### PR TITLE
add near_bindgen macro above impl of trait

### DIFF
--- a/contracts/rust/src/lib.rs
+++ b/contracts/rust/src/lib.rs
@@ -64,6 +64,7 @@ impl NonFungibleTokenBasic {
     }
 }
 
+#[near_bindgen]
 impl NEP4 for NonFungibleTokenBasic {
     fn grant_access(&mut self, escrow_account_id: AccountId) {
         let escrow_hash = env::sha256(escrow_account_id.as_bytes());


### PR DESCRIPTION
We missed an important macro needed to make these callable when on the chain